### PR TITLE
add GoogleAccount OAuth connection

### DIFF
--- a/redash/handlers/__init__.py
+++ b/redash/handlers/__init__.py
@@ -22,5 +22,6 @@ def status_api():
 
 def init_app(app):
     from redash.handlers import embed, queries, static, authentication, admin, setup
+    from redash.handlers import google_account_connect # crowdworks-extended
     app.register_blueprint(routes)
     api.init_app(app)

--- a/redash/handlers/google_account_connect.py
+++ b/redash/handlers/google_account_connect.py
@@ -1,0 +1,77 @@
+# coding: utf-8
+# crowdworks-extended
+
+import logging
+import base64
+import gzip
+from StringIO import StringIO
+from redash import settings
+from redash.permissions import require_admin
+from redash.handlers.base import BaseResource, routes
+
+from oauth2client.client import OAuth2WebServerFlow, FlowExchangeError
+from flask import request, url_for, redirect, render_template
+from flask_restful import abort
+
+
+def get_oauth_flow():
+    scopes = [
+        'https://www.googleapis.com/auth/userinfo.email',
+        'https://www.googleapis.com/auth/userinfo.profile',
+        'https://spreadsheets.google.com/feeds',
+        'https://www.googleapis.com/auth/admin.directory.group.member.readonly',
+        'https://www.googleapis.com/auth/admin.directory.group.readonly'
+    ]
+    flow = OAuth2WebServerFlow(
+        client_id=settings.GOOGLE_ACCOUNT_CONNECT_CLIENT_ID,
+        client_secret=settings.GOOGLE_ACCOUNT_CONNECT_CLIENT_SECRET,
+        scope=scopes,
+        redirect_uri=url_for('redash.datasource_google_connected_callback', _external=True),
+        access_type='offline',
+        prompt='consent'
+    )
+    return flow
+
+
+@routes.route('/google_account/connect', methods=['GET'], endpoint='datasource_google_connect')
+def data_source_google_oauth():
+    if not settings.GOOGLE_ACCOUNT_CONNECT_OAUTH_SERVER_ENABLED:
+        logging.info("data_source google_oauth skipped.")
+        abort(400)
+
+    flow = get_oauth_flow()
+
+    return redirect(flow.step1_get_authorize_url())
+
+
+@routes.route('/google_account/callback', methods=['GET'], endpoint='datasource_google_connected_callback')
+def data_source_google_oauth_callback():
+    if not settings.GOOGLE_ACCOUNT_CONNECT_OAUTH_SERVER_ENABLED:
+        logging.info("data_source google_oauth skipped.")
+        abort(400)
+
+    code = request.args.get('code', None)
+    if not code:
+        return redirect(url_for('redash.datasource_google_connect'))
+
+    flow = get_oauth_flow()
+
+    try:
+        credentials = flow.step2_exchange(code)
+    except FlowExchangeError as e:
+        logging.warn('except Error:', e)
+        return redirect(url_for('redash.datasource_google_connect'))
+
+    credential_json = credentials.to_json()
+    email = credentials.id_token['email']
+
+    io = StringIO()
+    with gzip.GzipFile(fileobj=io, mode='wb') as f:
+        f.write(credential_json)
+    token = base64.b64encode(io.getvalue())
+
+    text = "REDASH_GOOGLE_ACCOUNT_CONNECT_EMAIL={email}\nREDASH_GOOGLE_ACCOUNT_CONNECT_OAUTH_TOKEN={token}".format(
+        email=email,
+        token=token
+    )
+    return render_template("google_account_connected.html", text=text)

--- a/redash/settings.py
+++ b/redash/settings.py
@@ -101,6 +101,36 @@ GOOGLE_CLIENT_ID = os.environ.get("REDASH_GOOGLE_CLIENT_ID", "")
 GOOGLE_CLIENT_SECRET = os.environ.get("REDASH_GOOGLE_CLIENT_SECRET", "")
 GOOGLE_OAUTH_ENABLED = GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET
 
+# crowdworks-extended
+import base64
+import gzip
+from StringIO import StringIO
+GOOGLE_ACCOUNT_CONNECT_CLIENT_ID = os.environ.get("REDASH_GOOGLE_ACCOUNT_CONNECT_CLIENT_ID")
+GOOGLE_ACCOUNT_CONNECT_CLIENT_SECRET = os.environ.get("REDASH_GOOGLE_ACCOUNT_CONNECT_CLIENT_SECRET")
+GOOGLE_ACCOUNT_CONNECT_OAUTH_SERVER_ENABLED = GOOGLE_ACCOUNT_CONNECT_CLIENT_ID and GOOGLE_ACCOUNT_CONNECT_CLIENT_SECRET
+GOOGLE_ACCOUNT_CONNECT_EMAIL = os.environ.get("REDASH_GOOGLE_ACCOUNT_CONNECT_EMAIL")
+
+def _parse_google_account_connect_token():
+    if not GOOGLE_ACCOUNT_CONNECT_OAUTH_SERVER_ENABLED:
+        return None
+    b64token = os.environ.get("REDASH_GOOGLE_ACCOUNT_CONNECT_OAUTH_TOKEN")
+    if not b64token:
+        return None
+    gzip_token = base64.b64decode(b64token)
+
+    io = StringIO()
+    io.write(gzip_token)
+    io.seek(0)
+
+    json_token = None
+    with gzip.GzipFile(fileobj=io, mode='rb') as f:
+        json_token = f.read()
+
+    return json_token
+
+GOOGLE_ACCOUNT_CONNECT_OAUTH_TOKEN = _parse_google_account_connect_token()
+GOOGLE_ACCOUNT_CONNECT_OAUTH_ENABLED = GOOGLE_ACCOUNT_CONNECT_EMAIL and GOOGLE_ACCOUNT_CONNECT_OAUTH_TOKEN
+
 SAML_ENTITY_ID = os.environ.get("REDASH_SAML_ENTITY_ID", "")
 SAML_METADATA_URL = os.environ.get("REDASH_SAML_METADATA_URL", "")
 SAML_LOCAL_METADATA_PATH = os.environ.get("REDASH_SAML_LOCAL_METADATA_PATH", "")

--- a/redash/templates/google_account_connected.html
+++ b/redash/templates/google_account_connected.html
@@ -1,0 +1,18 @@
+<!-- crowdworks-extended -->
+{% extends "layouts/signed_out.html" %}
+{% block title %}Connected Google Account | Redash{% endblock %}
+
+{% block content %}
+    <h2>Connected Google Account</h2>
+
+    <form>
+        <div class="form-group">
+            <label for="text">Secret Token</label>
+            <textarea id="text" class="form-control" onClick="this.select();" rows="20">{{ text }}</textarea>
+        </div>
+
+        <button type="submit" class="btn btn btn-default" onClick="window.close();">
+            Close
+        </button>
+    </form>
+{% endblock %}


### PR DESCRIPTION
以下の用途で利用するGoogleアカウントの認証情報を取得する

 - Google Spreadsheet (By Personal User) の読み込み接続
 - Google Groups のメンバーと、 redash のグループとの同期
 - クエリ実行結果の Google Drive へのアップロード